### PR TITLE
Do not allow huge provider ids.

### DIFF
--- a/home_api_metrics.routing.yml
+++ b/home_api_metrics.routing.yml
@@ -16,6 +16,7 @@ home_api_metrics.accomodation.provider.open:
     _title: 'HOME metrics provider opened endpoint'
   requirements:
     _permission: 'use home api metrics endpoints'
+    provider_id: '.{1,200}' # Provider id should not be longer than 200 chars (DB field can hold up to 255 characters)
   options:
     _auth: ['key_auth', 'cookie'] # TODO: Remove 'key_auth' in release
     parameters:

--- a/src/Controller/HomeApiMetricsOpenController.php
+++ b/src/Controller/HomeApiMetricsOpenController.php
@@ -72,7 +72,6 @@ class HomeApiMetricsOpenController extends ControllerBase {
    */
   public function handleProviderOpen(Request $request, string $provider_id) {
     $time = $this->time->getRequestTime();
-    $group = $request->query->get('group');
 
     $entity = $this->homeApiMetricsService->addProviderOpen($time, $provider_id);
 


### PR DESCRIPTION
I discovered this via experimenting with the API:
```shell
# this works (final length in title field = 255)
curl http://localhost/accommodation/metrics/provider/open/2345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345 -H "Cookie: SSESS0e7ceb0e9c249e3843655ad6fbabadd0=REDACTED" --data '{}' -vvv

# this fails (final length in title field = 256)
curl http://localhost/accommodation/metrics/provider/open/23456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456 -H "Cookie: SSESS0e7ceb0e9c249e3843655ad6fbabadd0=REDACTED" --data '{}' -vvv
```

A long provider id throws an exception because the `title` db field is set to 255 max. We could substring, but a better solution is to simply not accept anything very long declaratively through the routing yml.